### PR TITLE
Support seeding from initialization files

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,8 @@ The :py:func:`initialize` function initializes the root seed and seeds all suppo
 
 .. autofunction:: initialize
 
+.. autofunction:: init_file
+
 Seed Material
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ dev = [
 test = [
     "pytest >= 6",
     "pytest-doctestplus",
-    "pytest-cov"
+    "pytest-cov",
+    "pyyaml",
+    "tomli",
     # "hypothesis",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dev = [
     "flake8",
     "ipython",
     "sphinx-autobuild",
+    "invoke",
+    "conda-lock",
 ]
 test = [
     "pytest >= 6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 requires-python = ">= 3.7"
 description-file = "README.md"
 requires = [
-    "numpy >=1.17"
+    "numpy >=1.17",
+    "anyconfig",
 ]
 
 [tool.flit.metadata.urls]

--- a/seedbank/__init__.py
+++ b/seedbank/__init__.py
@@ -63,6 +63,13 @@ def initialize(seed, *keys):
     return _root_state.seed
 
 
+def init_file(file, *keys, path='random.seed'):
+    """
+    Initialize the random infrastructure with a seed loaded from a file.  It supports YAML and
+    TOML files, and requires an appropriate parser installed.
+    """
+
+
 def derive_seed(*keys, base=None):
     """
     Derive a seed from the root seed, optionally with additional seed keys.

--- a/seedbank/__init__.py
+++ b/seedbank/__init__.py
@@ -65,9 +65,44 @@ def initialize(seed, *keys):
 
 def init_file(file, *keys, path='random.seed'):
     """
-    Initialize the random infrastructure with a seed loaded from a file.  It supports YAML and
-    TOML files, and requires an appropriate parser installed.
+    Initialize the random infrastructure with a seed loaded from a file. The loaded seed is
+    passed to :func:`initialize`, along with any additional RNG key material.
+
+    With the default ``path``, the seed can be configured from a TOML file as follows:
+
+    .. code-block:: toml
+
+        [random]
+        seed = 2308410
+
+    And then initialized::
+
+        seedbank.init_file('params.toml')
+
+    Any file type supported by anyconfig_ can be used, including TOML, YAML, and JSON.
+
+    .. _anyconfig: https://github.com/ssato/python-anyconfig
+
+    Args:
+        file(str or pathlib.Path):
+            The filename for the configuration file to load.
+        keys(list of int or str):
+            Aditional key material.
+        path(str):
+            The path within the configuration file or object in which the seed is stored.
+            Can be multiple keys separated with '.'.
     """
+    import anyconfig
+    _log.info('loading seed from %s (key=%s)', file, path)
+
+    config = anyconfig.load(file)
+
+    kps = path.split('.')
+    seed = config
+    for k in kps:
+        seed = seed[k]
+
+    initialize(seed, *keys)
 
 
 def derive_seed(*keys, base=None):

--- a/tests/init_seed.toml
+++ b/tests/init_seed.toml
@@ -1,0 +1,5 @@
+[random]
+seed = 202142
+
+[bird]
+seed = 202199

--- a/tests/init_seed.yaml
+++ b/tests/init_seed.yaml
@@ -1,0 +1,2 @@
+random:
+  seed: 202157

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 from seedbank import derive_seed, initialize, _root_state, root_seed, int_seed
 from seedbank._keys import make_key
 
+
 def test_initialize():
     initialize(42)
     assert _root_state.seed.entropy == 42

--- a/tests/test_init_file.py
+++ b/tests/test_init_file.py
@@ -1,0 +1,41 @@
+import os.path
+from pathlib import Path
+from seedbank import init_file, _root_state, root_seed
+
+test_dir = os.path.dirname(__file__)
+
+
+def test_init_toml_fn():
+    "Initialize with a TOML filename"
+    toml_file = os.path.join(test_dir, 'init_seed.toml')
+    init_file(toml_file)
+    assert _root_state.seed.entropy == 202142
+    assert len(_root_state.seed.spawn_key) == 0
+    assert root_seed().entropy == 202142
+
+
+def test_init_toml():
+    "Initialize witha TOML path"
+    toml_file = Path(test_dir) / 'init_seed.toml'
+    init_file(toml_file)
+    assert _root_state.seed.entropy == 202142
+    assert len(_root_state.seed.spawn_key) == 0
+    assert root_seed().entropy == 202142
+
+
+def test_init_yaml():
+    "Initialize with a YAML path"
+    yaml_file = Path(test_dir) / 'init_seed.yaml'
+    init_file(yaml_file)
+    assert _root_state.seed.entropy == 202157
+    assert len(_root_state.seed.spawn_key) == 0
+    assert root_seed().entropy == 202157
+
+
+def test_init_toml_path():
+    "Initialize with TOML and a custom configuration key."
+    toml_file = Path(test_dir) / 'init_seed.toml'
+    init_file(toml_file, path='bird.seed')
+    assert _root_state.seed.entropy == 202199
+    assert len(_root_state.seed.spawn_key) == 0
+    assert root_seed().entropy == 202199


### PR DESCRIPTION
This adds the `init_file` function to make it easier to initialize seeds from a configuration file.