### PR TITLE
Clean up CI and extend to Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         - "3.11"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -43,8 +43,8 @@ jobs:
     - name: Run tests
       run: python -m pytest --cov=seedbank --cov-report=xml tests
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Save test results
+      uses: lenskit/lkbuild/actions/save-test-results@main
 
   test-extra:
     name: Test single extra ${{matrix.extra}}
@@ -59,7 +59,7 @@ jobs:
         - tf
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -73,8 +73,22 @@ jobs:
     - name: Run tests
       run: python -m pytest --cov=seedbank --cov-report=xml tests
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Save test results
+      uses: lenskit/lkbuild/actions/save-test-results@main
+
+  report:
+    name: Process test results
+    runs-on: ubuntu-latest
+    needs: [test, test-extra]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Report test results
+      uses: lenskit/lkbuild/actions/report-test-results@main
+
 
   sdist:
     name: Build and Publish Packages
@@ -82,7 +96,7 @@ jobs:
     needs: [test, test-extra]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -90,7 +104,7 @@ jobs:
       run: git fetch --tags
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -101,7 +115,7 @@ jobs:
       run: flit build
 
     - name: Save archive
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: pypi-pkgs
         path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Save test results
       uses: lenskit/lkbuild/actions/save-test-results@main
+      with:
+        artifact-name: test-${{matrix.platform}}-py${{matrix.python}}
 
   test-extra:
     name: Test single extra ${{matrix.extra}}
@@ -75,6 +77,8 @@ jobs:
 
     - name: Save test results
       uses: lenskit/lkbuild/actions/save-test-results@main
+      with:
+        artifact-name: test-extra-${{matrix.extra}}
 
   report:
     name: Process test results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
 ]
 requires-python = ">= 3.7"


### PR DESCRIPTION
This extends the CI builds to use Python 3.11, and cleans them up to make better use of shared actions.