### PR TITLE
Update to Setuptools & drop Python 3.7.

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Changes here will be overwritten by Copier
-_commit: 9d9eb55
+_commit: 3f4b9e0
 _src_path: https://github.com/lenskit/lk-project-template.git
 package_name: seedbank
 project_name: seedbank
+project_title: SeedBank
 require_lint: true
 start_year: 2021

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 7f2b85a
+_commit: 0e64af4
 _src_path: https://github.com/lenskit/lk-project-template.git
 package_name: seedbank
 project_descr: Common infrastructure for seeding random number generators.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Changes here will be overwritten by Copier
-_commit: 3f4b9e0
+_commit: 7f2b85a
 _src_path: https://github.com/lenskit/lk-project-template.git
 package_name: seedbank
+project_descr: Common infrastructure for seeding random number generators.
 project_name: seedbank
 project_title: SeedBank
 require_lint: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
-[{*.yml,*.yaml,*.yml.jinja}]
+[{*.json,*.yml,*.yaml,*.yml.jinja}]
 indent_size = 2
 
 [*.toml]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,7 @@ jobs:
 
     - name: Set up dev environment
       run: |
-        pip install 'flit>=3.8'
-        flit install --only-deps --deps production --extras test
+        pip install -e '.[test]'
 
     - name: Run tests
       run: python -m pytest --cov=seedbank --cov-report=xml tests
@@ -77,8 +76,7 @@ jobs:
 
     - name: Set up dev environment
       run: |
-        pip install 'flit>=3.8'
-        flit install --only-deps --deps production --extras "test,${{matrix.extra}}"
+        pip install -e '.[test,${{matrix.extra}}]'
 
     - name: Run tests
       run: python -m pytest --cov=seedbank --cov-report=xml tests
@@ -121,10 +119,10 @@ jobs:
         python-version: 3.8
 
     - name: Install Python deps
-      run: pip install -U flit
+      run: pip install -U build
 
     - name: Build distribution
-      run: flit build
+      run: python -m build
 
     - name: Save archive
       uses: actions/upload-artifact@v3
@@ -138,9 +136,9 @@ jobs:
     - name: Publish PyPI packages
       if: github.event_name == 'release'
       run: |
-        flit publish
+        twine upload dist/*
       shell: bash
       env:
         TWINE_NON_INTERACTIVE: y
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
         - windows
         - ubuntu
         python:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ scratch/
 # build outputs
 build/
 dist/
+*.egg-info
 *.pyd
 *.so
 *.dll

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ conda-lock.yml
 *~
 *.tmp
 .vs/
-.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+  },
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,49 +1,40 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 import seedbank
 
-project = 'SeedBank'
-copyright = '2021 Boise State University'
-author = 'Michael D. Ekstrand'
+project = "SeedBank""
+copyright = "2023 Michael Ekstrand"
+author = "Michael D. Ekstrand"
 
 release = seedbank.__version__
 
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinxext.opengraph',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
 ]
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
-pygments_style = 'sphinx'
-highlight_language = 'python3'
+pygments_style = "sphinx"
+highlight_language = "python3"
 
-html_theme = 'furo'
+html_theme = "furo"
 html_theme_options = {
-    # 'github_user': 'lenskit',
-    # 'github_repo': 'seedbank',
 }
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'numba': ('https://numba.readthedocs.io/en/stable/', None),
-    'sklearn': ('https://scikit-learn.org/stable/', None),
-    'torch': ('https://pytorch.org/docs/stable/', None),
-    'cupy': ('https://docs.cupy.dev/en/stable/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 autodoc_default_options = {
-    'members': True,
-    'member-order': 'bysource'
-}
-
-napoleon_type_aliases = {
-    'seed-like': ':term:`seed-like`'
+    "members": True,
+    "member-order": "bysource"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 import seedbank
 
-project = "SeedBank""
+project = "SeedBank"
 copyright = "2023 Michael Ekstrand"
 author = "Michael D. Ekstrand"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,14 @@ authors = [
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
 ]
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 readme = "README.md"
 license = { file = "LICENSE.md" }
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "seedbank"
@@ -10,9 +10,6 @@ authors = [
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -20,6 +17,7 @@ classifiers = [
 ]
 requires-python = ">= 3.7"
 readme = "README.md"
+license = { file = "LICENSE.md" }
 dynamic = ["version", "description"]
 dependencies = [
   "numpy >=1.17",
@@ -28,14 +26,15 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "flit >=3.2",
+  "setuptools>=64",
+  "setuptools_scm>=8",
   "ruff",
   "copier",
   "ipython",
   "sphinx-autobuild",
 ]
 test = [
-  "pytest >= 6",
+  "pytest >= 7",
   "pytest-doctestplus",
   "pytest-cov",
   "pyyaml",
@@ -43,7 +42,7 @@ test = [
   # "hypothesis",
 ]
 doc = [
-  "sphinx >=4",
+  "sphinx >=4.2",
   "sphinxext-opengraph >= 0.5",
   "furo",
 ]
@@ -57,6 +56,14 @@ tf = ["tensorflow >=2,<3"]
 Homepage = "https://seedbank.lenksit.org"
 GitHub = "https://github.com/lenskit/seedbank"
 
+# configure build tools
+[tool.setuptools]
+packages = ["seedbank"]
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+
+# settings for generating conda environments for dev & CI, when needed
 [tool.pyproject2conda]
 channels = ["conda-forge"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seedbank"
-description = "Common infrastructure for initializing random number generators."
+description = "Common infrastructure for seeding random number generators."
 authors = [
   {name="Michael Ekstrand", email="mdekstrand@drexel.edu"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seedbank"
+description = "Common infrastructure for initializing random number generators."
 authors = [
   {name="Michael Ekstrand", email="mdekstrand@drexel.edu"}
 ]
@@ -18,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.7"
 readme = "README.md"
 license = { file = "LICENSE.md" }
-dynamic = ["version", "description"]
+dynamic = ["version"]
 dependencies = [
   "numpy >=1.17",
   "anyconfig ==0.13.*",


### PR DESCRIPTION
This updates to the latest Copier template, and uses setuptools + build + twine to build and upload. This also drops support for Python 3.7.