### PR TITLE
Correct use of non-int keys in derived seeds

### DIFF
--- a/.github/workflows/check-sources.yml
+++ b/.github/workflows/check-sources.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: 🛠️ Install development tools and dependencies
@@ -73,10 +73,10 @@ jobs:
           LINT_PASSED: ${{ steps.lint.outputs.passed }}
           LINT_REQUIRED: True
 
-      
+
       - name: 📐 Check types
         id: typecheck
         uses: jakebailey/pyright-action@v1
         with:
           extra-args: seedbank
-      
+

--- a/seedbank/_keys.py
+++ b/seedbank/_keys.py
@@ -1,13 +1,23 @@
 # pyright: reportUnnecessaryIsInstance=false
 import hashlib
+from typing import Any, Literal, Sequence, TypeAlias, overload
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import Any, Sequence, TypeAlias
 
 Entropy: TypeAlias = int | Sequence[int] | npt.NDArray[np.uint32]
 RNGKey: TypeAlias = int | np.integer[Any] | npt.NDArray[Any] | bytes | memoryview | str
 SeedLike: TypeAlias = np.random.SeedSequence | RNGKey
+
+
+@overload
+def make_key(data: RNGKey, single: Literal[True]) -> int:
+    ...
+
+
+@overload
+def make_key(data: RNGKey, single: bool = False) -> Entropy:
+    ...
 
 
 def make_key(data: RNGKey, single: bool = False) -> Entropy:

--- a/seedbank/_keys.py
+++ b/seedbank/_keys.py
@@ -32,7 +32,7 @@ def make_key(data: RNGKey, single: bool = False) -> Entropy:
         return int(data)
     if isinstance(data, np.ndarray):
         if single:
-            return make_key(memoryview(data), single)
+            return make_key(memoryview(data), True)
         else:
             return data.astype(np.uint32)
     if isinstance(data, (bytes, memoryview)):

--- a/seedbank/_state.py
+++ b/seedbank/_state.py
@@ -77,8 +77,8 @@ class SeedState:
             base = make_seed(base)
 
         if keys:
-            k2 = tuple(make_key(k) for k in keys)
-            seed = np.random.SeedSequence(base.entropy, spawn_key=base.spawn_key + k2)  # type: ignore
+            k2 = tuple(make_key(k, True) for k in keys)
+            seed = np.random.SeedSequence(base.entropy, spawn_key=base.spawn_key + k2)
         else:
             seed = base.spawn(1)[0]
 

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -1,4 +1,4 @@
-from seedbank import initialize, derive_seed
+from seedbank import derive_seed, initialize
 from seedbank._keys import make_key
 
 
@@ -20,4 +20,4 @@ def test_derive_seed_str():
     initialize(42)
     s2 = derive_seed(b"wombat")
     assert s2.entropy == 42
-    assert all(s2.spawn_key[0] == make_key(b"wombat"))
+    assert s2.spawn_key[0] == make_key(b"wombat", True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,8 +12,8 @@ def test_initialize():
 def test_initialize_key():
     initialize(42, "wombat")
     assert _root_state.seed.entropy == 42
-    k = make_key("wombat")
-    assert all(_root_state.seed.spawn_key[0] == k)
+    k = make_key("wombat", True)
+    assert _root_state.seed.spawn_key[0] == k
     assert root_seed().entropy == 42
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-from seedbank import derive_seed, initialize, _root_state, root_seed, int_seed
+from seedbank import _root_state, derive_seed, initialize, int_seed, root_seed
 from seedbank._keys import make_key
 
 

--- a/tests/test_process_seed.py
+++ b/tests/test_process_seed.py
@@ -34,3 +34,8 @@ def test_make_key_ndarray():
     key = make_key(src)
     assert isinstance(key, np.ndarray)
     assert all(key == src)
+
+
+def test_make_key_str_int():
+    key = make_key("hello, world", True)
+    assert isinstance(key, int)

--- a/tests/test_process_seed.py
+++ b/tests/test_process_seed.py
@@ -1,0 +1,36 @@
+"""
+Tests for processing seed material.
+"""
+
+import numpy as np
+
+from seedbank._keys import make_key
+
+
+def test_make_key_int():
+    key = make_key(42)
+    assert key == 42
+
+
+def test_make_key_npint():
+    key = make_key(np.int32(42))
+    assert key == 42
+
+
+def test_make_key_str():
+    key = make_key("hello, world")
+    assert isinstance(key, np.ndarray)
+    assert len(key) >= 4
+
+
+def test_make_key_bytes():
+    key = make_key(b"hello, world")
+    assert isinstance(key, np.ndarray)
+    assert len(key) >= 4
+
+
+def test_make_key_ndarray():
+    src = np.random.randint(500, size=32)
+    key = make_key(src)
+    assert isinstance(key, np.ndarray)
+    assert all(key == src)


### PR DESCRIPTION
The SeedSequence API specifies that spawn keys need to be sequences of integers. Passing sequences of ndarrays worked, but this was out-of-spec from the NumPy documentation.

This PR adds the ability to create integer seeds from `make_key`, using a 64-bit BLAKE2 hash of non-int key material, and uses it to create the spawn keys to extend a seed state.